### PR TITLE
allow phpspec usage on php5.5.9

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,9 +8,9 @@
     },
 
     "require" : {
-        "php": "^5.6|^7.0",
+        "php": "^5.6|^7.0|^5.5",
         "phpspec/phpspec": "^2.0",
-        "phpunit/php-code-coverage": "^3"
+        "phpunit/php-code-coverage": "^3|2.2.4"
     },
 
     "suggest": {


### PR DESCRIPTION
ubuntu 14.04 LTS ships by default with php 5.5.9. until a new ubuntu LTS becomes available, the extension should allow usage for this PHP version. based on my tests, everything works OK.
